### PR TITLE
Add JWT authentication module

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,10 @@ These values are for testing only.
 - `GET /users` – list all users
 - `POST /users` – add a new user (`{ username, password }`)
 
+### Authentication
+- `POST /auth/register` – create a new account (`{ name, email, password, role }`)
+- `POST /auth/login` – obtain a JWT (`{ email, password }`)
+
 ### Projects
 - `GET /projects` – list all projects
 - `POST /projects` – add a new project (`{ name, description }`)

--- a/server/auth.js
+++ b/server/auth.js
@@ -1,0 +1,60 @@
+const express = require('express');
+const bcrypt = require('bcrypt');
+const jwt = require('jsonwebtoken');
+const { getUsers, addUser } = require('./db');
+
+const router = express.Router();
+const JWT_SECRET = process.env.JWT_SECRET || 'changeme';
+const SALT_ROUNDS = 10;
+
+// POST /auth/register
+router.post('/register', async (req, res) => {
+  const { name, email, password, role } = req.body;
+  if (!name || !email || !password || !role) {
+    return res
+      .status(400)
+      .json({ error: 'name, email, password and role required' });
+  }
+  if (!['dentist', 'specialist'].includes(role)) {
+    return res.status(400).json({ error: 'invalid role' });
+  }
+  const existing = getUsers().find((u) => u.email === email);
+  if (existing) {
+    return res.status(400).json({ error: 'email already registered' });
+  }
+  try {
+    const passwordHash = await bcrypt.hash(password, SALT_ROUNDS);
+    const user = addUser({ name, email, passwordHash, role });
+    return res.status(201).json({ id: user.id });
+  } catch (err) {
+    return res.status(500).json({ error: 'registration failed' });
+  }
+});
+
+// POST /auth/login
+router.post('/login', async (req, res) => {
+  const { email, password } = req.body;
+  if (!email || !password) {
+    return res.status(400).json({ error: 'email and password required' });
+  }
+  const user = getUsers().find((u) => u.email === email);
+  if (!user) {
+    return res.status(401).json({ error: 'Invalid credentials' });
+  }
+  try {
+    const match = await bcrypt.compare(password, user.passwordHash);
+    if (!match) {
+      return res.status(401).json({ error: 'Invalid credentials' });
+    }
+    const token = jwt.sign(
+      { id: user.id, role: user.role },
+      JWT_SECRET,
+      { expiresIn: '1h' }
+    );
+    return res.json({ token, role: user.role });
+  } catch (err) {
+    return res.status(500).json({ error: 'login failed' });
+  }
+});
+
+module.exports = { router, JWT_SECRET };

--- a/server/authMiddleware.js
+++ b/server/authMiddleware.js
@@ -1,0 +1,24 @@
+const jwt = require('jsonwebtoken');
+const { JWT_SECRET } = require('./auth');
+
+function authenticate(role) {
+  return (req, res, next) => {
+    const header = req.headers.authorization || '';
+    const token = header.replace('Bearer ', '');
+    if (!token) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+    try {
+      const payload = jwt.verify(token, JWT_SECRET);
+      if (role && payload.role !== role) {
+        return res.status(403).json({ error: 'Forbidden' });
+      }
+      req.user = payload;
+      return next();
+    } catch (err) {
+      return res.status(401).json({ error: 'Unauthorized' });
+    }
+  };
+}
+
+module.exports = authenticate;

--- a/server/models/User.js
+++ b/server/models/User.js
@@ -1,0 +1,11 @@
+class User {
+  constructor({ name, email, passwordHash, role }) {
+    this.id = null; // assigned when stored
+    this.name = name;
+    this.email = email;
+    this.passwordHash = passwordHash;
+    this.role = role; // 'dentist' or 'specialist'
+  }
+}
+
+module.exports = User;

--- a/server/package.json
+++ b/server/package.json
@@ -10,8 +10,10 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "bcrypt": "^5.1.1",
     "cors": "^2.8.5",
     "express": "^5.1.0",
+    "jsonwebtoken": "^9.0.2",
     "serverless-http": "^3.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add `/auth` routes with bcrypt password hashing and JWTs
- implement role-based auth middleware
- document new endpoints in README
- provide a simple `User` model example

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68472f6f38ec8323984fb6423717afcc