### PR TITLE
Add React Hook Form login/registration UI

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
-    "react-router-dom": "^6.30.1"
+    "react-router-dom": "^6.30.1",
+    "react-hook-form": "^7.45.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -11,6 +11,7 @@ const Contact = lazy(() => import('./pages/Contact.jsx'));
 const Portal = lazy(() => import('./pages/Portal.jsx'));
 const Login = lazy(() => import('./pages/Login.jsx'));
 const Register = lazy(() => import('./pages/Register.jsx'));
+const Dashboard = lazy(() => import('./pages/Dashboard.jsx'));
 const Projects = lazy(() => import('./pages/Projects.jsx'));
 const ProjectDetail = lazy(() => import('./pages/ProjectDetail.jsx'));
 
@@ -30,6 +31,7 @@ function App() {
           <Route path="portal" element={<Portal />} />
           <Route path="login" element={<Login />} />
           <Route path="register" element={<Register />} />
+          <Route path="dashboard" element={<Dashboard />} />
           <Route path="projects" element={<Projects />} />
           <Route path="projects/:id" element={<ProjectDetail />} />
          </Route>

--- a/client/src/components/Header.jsx
+++ b/client/src/components/Header.jsx
@@ -63,20 +63,30 @@ function Header({ onNavigate }) {
             </NavLink>
           </li>
           <li>
-            <NavLink
-              to="/portal"
-              className={({ isActive }) =>
-                `${isActive ? 'border-b-2 font-semibold' : ''} hover:text-gray-200`
-              }
-            >
-              Portal
-            </NavLink>
-          </li>
-          <li>
-            <NavLink
-              to="/login"
-              className={({ isActive }) =>
-                `${isActive ? 'border-b-2 font-semibold' : ''} hover:text-gray-200`
+          <NavLink
+            to="/portal"
+            className={({ isActive }) =>
+              `${isActive ? 'border-b-2 font-semibold' : ''} hover:text-gray-200`
+            }
+          >
+            Portal
+          </NavLink>
+        </li>
+        <li>
+          <NavLink
+            to="/dashboard"
+            className={({ isActive }) =>
+              `${isActive ? 'border-b-2 font-semibold' : ''} hover:text-gray-200`
+            }
+          >
+            Dashboard
+          </NavLink>
+        </li>
+        <li>
+          <NavLink
+            to="/login"
+            className={({ isActive }) =>
+              `${isActive ? 'border-b-2 font-semibold' : ''} hover:text-gray-200`
               }
             >
               Login

--- a/client/src/components/LoginForm.jsx
+++ b/client/src/components/LoginForm.jsx
@@ -1,0 +1,67 @@
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import { setAuth } from '../utils/auth.js';
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000';
+
+function LoginForm() {
+  const { register, handleSubmit, formState: { errors } } = useForm();
+  const [apiError, setApiError] = useState('');
+  const navigate = useNavigate();
+
+  const onSubmit = async (data) => {
+    setApiError('');
+    try {
+      const res = await fetch(`${API_BASE}/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error || 'Login failed');
+      }
+      const result = await res.json();
+      setAuth(result.token, result.role);
+      navigate('/dashboard');
+    } catch (err) {
+      setApiError(err.message);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 p-4 bg-white shadow rounded">
+      {apiError && <p className="text-red-500">{apiError}</p>}
+      <div>
+        <label className="block mb-1">Email</label>
+        <input
+          type="email"
+          className="border p-2 w-full rounded"
+          {...register('email', {
+            required: 'Email is required',
+            pattern: {
+              value: /^[^@\s]+@[^@\s]+\.[^@\s]+$/,
+              message: 'Invalid email',
+            },
+          })}
+        />
+        {errors.email && <p className="text-red-500 text-sm">{errors.email.message}</p>}
+      </div>
+      <div>
+        <label className="block mb-1">Password</label>
+        <input
+          type="password"
+          className="border p-2 w-full rounded"
+          {...register('password', { required: 'Password is required' })}
+        />
+        {errors.password && <p className="text-red-500 text-sm">{errors.password.message}</p>}
+      </div>
+      <button type="submit" className="w-full bg-teal-500 text-white py-2 rounded">
+        Login
+      </button>
+    </form>
+  );
+}
+
+export default LoginForm;

--- a/client/src/components/RegisterForm.jsx
+++ b/client/src/components/RegisterForm.jsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+
+const API_BASE = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000';
+
+function RegisterForm() {
+  const { register, handleSubmit, formState: { errors } } = useForm({
+    defaultValues: { role: 'dentist' },
+  });
+  const [apiError, setApiError] = useState('');
+  const navigate = useNavigate();
+
+  const onSubmit = async (data) => {
+    setApiError('');
+    try {
+      const res = await fetch(`${API_BASE}/auth/register`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data),
+      });
+      if (!res.ok) {
+        const err = await res.json();
+        throw new Error(err.error || 'Registration failed');
+      }
+      navigate('/login');
+    } catch (err) {
+      setApiError(err.message);
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4 p-4 bg-white shadow rounded">
+      {apiError && <p className="text-red-500">{apiError}</p>}
+      <div>
+        <label className="block mb-1">Name</label>
+        <input
+          className="border p-2 w-full rounded"
+          {...register('name', { required: 'Name is required' })}
+        />
+        {errors.name && <p className="text-red-500 text-sm">{errors.name.message}</p>}
+      </div>
+      <div>
+        <label className="block mb-1">Email</label>
+        <input
+          type="email"
+          className="border p-2 w-full rounded"
+          {...register('email', {
+            required: 'Email is required',
+            pattern: {
+              value: /^[^@\s]+@[^@\s]+\.[^@\s]+$/,
+              message: 'Invalid email',
+            },
+          })}
+        />
+        {errors.email && <p className="text-red-500 text-sm">{errors.email.message}</p>}
+      </div>
+      <div>
+        <label className="block mb-1">Password</label>
+        <input
+          type="password"
+          className="border p-2 w-full rounded"
+          {...register('password', { required: 'Password is required' })}
+        />
+        {errors.password && <p className="text-red-500 text-sm">{errors.password.message}</p>}
+      </div>
+      <div>
+        <label className="block mb-1">Role</label>
+        <select className="border p-2 w-full rounded" {...register('role', { required: true })}>
+          <option value="dentist">Dentist</option>
+          <option value="specialist">Specialist</option>
+        </select>
+      </div>
+      <button type="submit" className="w-full bg-teal-500 text-white py-2 rounded">
+        Register
+      </button>
+    </form>
+  );
+}
+
+export default RegisterForm;

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+function Dashboard() {
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl font-bold mb-4">Dashboard</h2>
+      <p>Welcome to your dashboard.</p>
+    </div>
+  );
+}
+
+export default Dashboard;

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,51 +1,12 @@
-import React, { useState } from 'react';
-import { useNavigate, Link } from 'react-router-dom';
-import { setAuth } from '../utils/auth.js';
-
-const API_BASE = 'http://localhost:3000';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import LoginForm from '../components/LoginForm.jsx';
 
 function Login() {
-  const [form, setForm] = useState({ username: '', password: '' });
-  const navigate = useNavigate();
-
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    fetch(`${API_BASE}/portal/login`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(form),
-    })
-      .then(async (r) => {
-        if (!r.ok) throw new Error('Login failed');
-        const data = await r.json();
-        setAuth(data.token, data.role);
-        navigate('/portal');
-      })
-      .catch(() => alert('Invalid credentials'));
-  };
-
   return (
     <div className="p-4 max-w-md mx-auto">
-      <h2 className="text-xl font-bold mb-4">Login</h2>
-      <form onSubmit={handleSubmit} className="space-y-2">
-        <input
-          type="text"
-          placeholder="Username"
-          value={form.username}
-          onChange={(e) => setForm({ ...form, username: e.target.value })}
-          className="border p-2 w-full"
-        />
-        <input
-          type="password"
-          placeholder="Password"
-          value={form.password}
-          onChange={(e) => setForm({ ...form, password: e.target.value })}
-          className="border p-2 w-full"
-        />
-        <button type="submit" className="bg-blue-500 text-white px-4 py-2 w-full">
-          Login
-        </button>
-      </form>
+      <h2 className="text-xl font-bold mb-4 text-center">Login</h2>
+      <LoginForm />
       <p className="mt-2 text-center">
         Need an account? <Link to="/register" className="text-blue-500 underline">Register</Link>
       </p>

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -1,58 +1,12 @@
-import React, { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-
-const API_BASE = 'http://localhost:3000';
+import React from 'react';
+import { Link } from 'react-router-dom';
+import RegisterForm from '../components/RegisterForm.jsx';
 
 function Register() {
-  const [form, setForm] = useState({ username: '', password: '', role: 'dentist' });
-  const navigate = useNavigate();
-
-  const handleSubmit = (e) => {
-    e.preventDefault();
-    fetch(`${API_BASE}/portal/signup`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(form),
-    })
-      .then((r) => {
-        if (!r.ok) throw new Error();
-        alert('Account created');
-        navigate('/login');
-      })
-      .catch(() => alert('Signup failed'));
-  };
-
   return (
     <div className="p-4 max-w-md mx-auto">
-      <h2 className="text-xl font-bold mb-4">Register</h2>
-      <form onSubmit={handleSubmit} className="space-y-2">
-        <input
-          type="text"
-          placeholder="Username"
-          value={form.username}
-          onChange={(e) => setForm({ ...form, username: e.target.value })}
-          className="border p-2 w-full"
-        />
-        <input
-          type="password"
-          placeholder="Password"
-          value={form.password}
-          onChange={(e) => setForm({ ...form, password: e.target.value })}
-          className="border p-2 w-full"
-        />
-        <select
-          value={form.role}
-          onChange={(e) => setForm({ ...form, role: e.target.value })}
-          className="border p-2 w-full"
-        >
-          <option value="dentist">Dentist</option>
-          <option value="specialist">Specialist</option>
-          <option value="admin">Admin</option>
-        </select>
-        <button type="submit" className="bg-green-500 text-white px-4 py-2 w-full">
-          Sign Up
-        </button>
-      </form>
+      <h2 className="text-xl font-bold mb-4 text-center">Register</h2>
+      <RegisterForm />
       <p className="mt-2 text-center">
         Already have an account? <Link to="/login" className="text-blue-500 underline">Login</Link>
       </p>


### PR DESCRIPTION
## Summary
- add `react-hook-form` dependency
- create `LoginForm` and `RegisterForm` components with validation
- refactor login and register pages to use new forms
- add simple `Dashboard` page and route
- link to Dashboard from header

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68473654b4f08323b1a196eca8cbd83d