### PR TITLE
Add MongoDB connection support

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,15 @@ Set `VITE_API_BASE_URL` in `client/.env` to your deployed API URL. Example:
 ```
 VITE_API_BASE_URL=https://u9x019avhh.execute-api.me-south-1.amazonaws.com
 ```
+
+## Backend Configuration
+
+Create a `.env` file inside the `server` directory based on `.env.example` and
+provide your MongoDB Atlas password. Example:
+
+```bash
+cp server/.env.example server/.env
+# edit server/.env and replace <db_password>
+```
+
+The Express server will automatically connect to the `MONGO_URI` when it starts.

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,0 +1,6 @@
+# Example environment configuration for server
+# Replace <db_password> with your actual MongoDB Atlas password
+MONGO_URI=mongodb+srv://haithammelbahrawy:<db_password>@cluster0.msookvg.mongodb.net/?retryWrites=true&w=majority&appName=Cluster0
+
+# Secret used to sign JWTs
+JWT_SECRET=changeme

--- a/server/index.js
+++ b/server/index.js
@@ -2,6 +2,7 @@ const express = require('express');
 const cors = require('cors');
 const serverless = require('serverless-http');
 const crypto = require('crypto');
+const connectMongo = require('./mongoConnect');
 
 const { router: authRouter } = require('./auth');
 const authenticate = require('./authMiddleware');
@@ -24,6 +25,7 @@ const requireAuth = authenticate();
 
 const app = express();
 const tokens = new Map();
+connectMongo();
 app.use(cors());
 app.use(express.json());
 

--- a/server/mongoConnect.js
+++ b/server/mongoConnect.js
@@ -1,0 +1,24 @@
+const mongoose = require('mongoose');
+
+const MONGO_URI = process.env.MONGO_URI;
+
+async function connectMongo() {
+  if (!MONGO_URI) {
+    console.warn('MONGO_URI not set; skipping MongoDB connection');
+    return;
+  }
+  if (mongoose.connection.readyState === 1) {
+    return;
+  }
+  try {
+    await mongoose.connect(MONGO_URI, {
+      useNewUrlParser: true,
+      useUnifiedTopology: true,
+    });
+    console.log('Connected to MongoDB');
+  } catch (err) {
+    console.error('MongoDB connection error:', err);
+  }
+}
+
+module.exports = connectMongo;

--- a/server/package.json
+++ b/server/package.json
@@ -14,7 +14,8 @@
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
-    "serverless-http": "^3.2.0"
+    "serverless-http": "^3.2.0",
+    "mongoose": "^7.6.1"
   },
   "devDependencies": {
     "serverless-offline": "^14.4.0"


### PR DESCRIPTION
## Summary
- add `mongoose` dependency
- implement `mongoConnect` helper for connecting to MongoDB using `MONGO_URI`
- initiate MongoDB connection in Express server
- provide `.env.example` with connection string and document setup in README

## Testing
- `npm install mongoose@7.6.1` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_684739c164988323904511aca197266d