### PR TITLE
Fix Tailwind 4 PostCSS setup

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -26,6 +26,7 @@
     "eslint-plugin-react-refresh": "^0.4.19",
     "globals": "^16.0.0",
     "postcss": "^8.5.4",
+    "@tailwindcss/postcss": "^0.1.0",
     "tailwindcss": "^4.1.8",
     "vite": "^6.3.5"
   }

--- a/client/postcss.config.js
+++ b/client/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    tailwindcss: {},
+    '@tailwindcss/postcss': {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
## Summary
- update PostCSS config to use `@tailwindcss/postcss`
- add the missing dev dependency in `package.json`

## Testing
- `npm run lint` *(fails: Cannot find package 'globals' because dependencies are not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684746cb0a448323b93d9ed8ef426d66