### PR TITLE
Fix PostCSS plugin

### DIFF
--- a/client/postcss.config.js
+++ b/client/postcss.config.js
@@ -1,6 +1,6 @@
 export default {
   plugins: {
-    '@tailwindcss/postcss': {},
+    tailwindcss: {},
     autoprefixer: {},
   },
 };


### PR DESCRIPTION
## Summary
- fix PostCSS config to use `tailwindcss`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847496904a08323b018f51a77642ded