### PR TITLE
Fix Tailwind/PostCSS config

### DIFF
--- a/client/postcss.config.js
+++ b/client/postcss.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   content: [
     "./index.html",
     "./src/**/*.{js,jsx,ts,tsx}"


### PR DESCRIPTION
## Summary
- update `postcss.config.js` to use `module.exports`
- switch `tailwind.config.js` to CommonJS style

## Testing
- `npm install -D tailwindcss postcss autoprefixer` *(fails: 403 Forbidden)*
- `npm run dev` *(fails: vite not found)*


------
https://chatgpt.com/codex/tasks/task_e_68474c67212c8323bcc046f31d1d4156