### PR TITLE
Fix portal login

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ These values are for testing only.
 - `POST /projects` – add a new project (`{ name, description }`)
 
 The existing `/portal` routes for case management continue to work as before.
+Use `POST /portal/signup` and `POST /portal/login` with `username` and `password`
+to access these endpoints.
 
 ## Connecting the Frontend
 

--- a/client/src/components/LoginForm.jsx
+++ b/client/src/components/LoginForm.jsx
@@ -21,7 +21,7 @@ function LoginForm() {
   const onSubmit = async (data) => {
     setApiError('');
     try {
-      const url = API_BASE ? `${API_BASE}/auth/login` : '/auth/login';
+      const url = API_BASE ? `${API_BASE}/portal/login` : '/portal/login';
       const res = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -33,7 +33,7 @@ function LoginForm() {
       }
       const result = await res.json();
       setAuth(result.token, result.role);
-      navigate('/dashboard');
+      navigate('/portal');
     } catch (err) {
       setApiError(err.message);
     }
@@ -42,19 +42,15 @@ function LoginForm() {
   return (
     <Box as="form" onSubmit={handleSubmit(onSubmit)} p={4} bg="white" shadow="md" rounded="md">
       {apiError && <Box color="red.500">{apiError}</Box>}
-      <FormControl isInvalid={errors.email} mb={4}>
-        <FormLabel>Email</FormLabel>
+      <FormControl isInvalid={errors.username} mb={4}>
+        <FormLabel>Username</FormLabel>
         <Input
-          type="email"
-          {...register('email', {
-            required: 'Email is required',
-            pattern: {
-              value: /^[^@\s]+@[^@\s]+\.[^@\s]+$/,
-              message: 'Invalid email',
-            },
+          type="text"
+          {...register('username', {
+            required: 'Username is required',
           })}
         />
-        <FormErrorMessage>{errors.email && errors.email.message}</FormErrorMessage>
+        <FormErrorMessage>{errors.username && errors.username.message}</FormErrorMessage>
       </FormControl>
       <FormControl isInvalid={errors.password} mb={4}>
         <FormLabel>Password</FormLabel>

--- a/client/src/components/RegisterForm.jsx
+++ b/client/src/components/RegisterForm.jsx
@@ -23,7 +23,7 @@ function RegisterForm() {
   const onSubmit = async (data) => {
     setApiError('');
     try {
-      const url = API_BASE ? `${API_BASE}/auth/register` : '/auth/register';
+      const url = API_BASE ? `${API_BASE}/portal/signup` : '/portal/signup';
       const res = await fetch(url, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -42,24 +42,10 @@ function RegisterForm() {
   return (
     <Box as="form" onSubmit={handleSubmit(onSubmit)} p={4} bg="white" shadow="md" rounded="md">
       {apiError && <Box color="red.500">{apiError}</Box>}
-      <FormControl isInvalid={errors.name} mb={4}>
-        <FormLabel>Name</FormLabel>
-        <Input {...register('name', { required: 'Name is required' })} />
-        <FormErrorMessage>{errors.name && errors.name.message}</FormErrorMessage>
-      </FormControl>
-      <FormControl isInvalid={errors.email} mb={4}>
-        <FormLabel>Email</FormLabel>
-        <Input
-          type="email"
-          {...register('email', {
-            required: 'Email is required',
-            pattern: {
-              value: /^[^@\s]+@[^@\s]+\.[^@\s]+$/,
-              message: 'Invalid email',
-            },
-          })}
-        />
-        <FormErrorMessage>{errors.email && errors.email.message}</FormErrorMessage>
+      <FormControl isInvalid={errors.username} mb={4}>
+        <FormLabel>Username</FormLabel>
+        <Input {...register('username', { required: 'Username is required' })} />
+        <FormErrorMessage>{errors.username && errors.username.message}</FormErrorMessage>
       </FormControl>
       <FormControl isInvalid={errors.password} mb={4}>
         <FormLabel>Password</FormLabel>


### PR DESCRIPTION
## Summary
- call `/portal/login` and `/portal/signup` from React forms
- adjust forms to use username rather than email
- mention portal auth routes in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684758be818483239c0148fb1c4e8b95