### PR TITLE
Fix API base URL handling

### DIFF
--- a/client/src/components/LoginForm.jsx
+++ b/client/src/components/LoginForm.jsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { setAuth } from '../utils/auth.js';
+import { getApiBase } from '../utils/api.js';
 import {
   Box,
   Input,
@@ -11,7 +12,7 @@ import {
   FormErrorMessage,
 } from '@chakra-ui/react';
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL;
+const API_BASE = getApiBase();
 
 function LoginForm() {
   const { register, handleSubmit, formState: { errors } } = useForm();

--- a/client/src/components/RegisterForm.jsx
+++ b/client/src/components/RegisterForm.jsx
@@ -11,7 +11,9 @@ import {
   FormErrorMessage,
 } from '@chakra-ui/react';
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL;
+import { getApiBase } from '../utils/api.js';
+
+const API_BASE = getApiBase();
 
 function RegisterForm() {
   const { register, handleSubmit, formState: { errors } } = useForm({

--- a/client/src/pages/Portal.jsx
+++ b/client/src/pages/Portal.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { getToken, getRole } from '../utils/auth.js';
+import { getApiBase } from '../utils/api.js';
 import {
   Box,
   Heading,
@@ -19,7 +20,7 @@ import {
   Text,
 } from '@chakra-ui/react';
 
-const API_BASE = 'http://localhost:3000';
+const API_BASE = getApiBase();
 
 function Portal() {
   const [token, setToken] = useState(getToken());

--- a/client/src/pages/ProjectDetail.jsx
+++ b/client/src/pages/ProjectDetail.jsx
@@ -9,8 +9,9 @@ import {
   Image,
   SimpleGrid,
 } from '@chakra-ui/react';
+import { getApiBase } from '../utils/api.js';
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000';
+const API_BASE = getApiBase();
 
 function ProjectDetail() {
   const { id } = useParams();

--- a/client/src/pages/Projects.jsx
+++ b/client/src/pages/Projects.jsx
@@ -12,7 +12,9 @@ import {
   Link,
 } from '@chakra-ui/react';
 
-const API_BASE = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000';
+import { getApiBase } from '../utils/api.js';
+
+const API_BASE = getApiBase();
 
 function Projects() {
   const [projects, setProjects] = useState([]);

--- a/client/src/utils/api.js
+++ b/client/src/utils/api.js
@@ -1,0 +1,4 @@
+export function getApiBase() {
+  const base = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3000';
+  return base.replace(/\/+$/, '');
+}


### PR DESCRIPTION
## Summary
- centralize API base URL handling with new `getApiBase` helper
- use the helper across the portal and project pages
- update login and registration forms to use sanitized base URL

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68475d4eae208323b83c6ce4295440e1