### PR TITLE
Fix env loading for local server

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -1,3 +1,4 @@
+require('dotenv').config();
 const express = require('express');
 const cors = require('cors');
 const serverless = require('serverless-http');


### PR DESCRIPTION
## Summary
- ensure server loads `.env` automatically so MONGO_URI is available

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68476094fc8c8323b127f2cb0ed3a8eb