### PR TITLE
Add SendGrid notification service

### DIFF
--- a/server/notificationService.js
+++ b/server/notificationService.js
@@ -1,0 +1,50 @@
+const sgMail = require('@sendgrid/mail');
+
+const API_KEY = process.env.SENDGRID_API_KEY;
+const FROM_EMAIL = process.env.NOTIFY_FROM_EMAIL || 'noreply@example.com';
+
+if (API_KEY) {
+  sgMail.setApiKey(API_KEY);
+} else {
+  console.warn('SENDGRID_API_KEY not set; emails will not be sent');
+}
+
+async function sendWithRetry(msg, attempt = 0) {
+  try {
+    await sgMail.send(msg);
+    console.log(`Email sent to ${msg.to}`);
+  } catch (err) {
+    console.error(`Failed to send email to ${msg.to}:`, err.message);
+    if (attempt < 2) {
+      console.log(`Retrying (${attempt + 1}) for ${msg.to}`);
+      return sendWithRetry(msg, attempt + 1);
+    }
+  }
+}
+
+async function sendCaseReady(toEmail, caseId) {
+  const msg = {
+    to: toEmail,
+    from: FROM_EMAIL,
+    subject: 'Your report is ready',
+    text: `Your report for case ${caseId} is ready.`,
+    html: `<p>Your report for case <strong>${caseId}</strong> is ready.</p>`,
+  };
+  await sendWithRetry(msg);
+}
+
+async function sendNewRequest(toEmail, caseId) {
+  const msg = {
+    to: toEmail,
+    from: FROM_EMAIL,
+    subject: 'New case assigned',
+    text: `A new case (${caseId}) has been assigned to you.`,
+    html: `<p>A new case (<strong>${caseId}</strong>) has been assigned to you.</p>`,
+  };
+  await sendWithRetry(msg);
+}
+
+module.exports = {
+  sendCaseReady,
+  sendNewRequest,
+};

--- a/server/package.json
+++ b/server/package.json
@@ -10,15 +10,16 @@
   "license": "ISC",
   "description": "",
   "dependencies": {
+    "@aws-sdk/client-s3": "^3.496.0",
+    "@sendgrid/mail": "^7.7.0",
     "bcrypt": "^5.1.1",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^7.6.1",
-    "serverless-http": "^3.2.0",
     "multer": "^1.4.5-lts.1",
-    "@aws-sdk/client-s3": "^3.496.0"
+    "serverless-http": "^3.2.0"
   },
   "devDependencies": {
     "serverless-offline": "^14.4.0"


### PR DESCRIPTION
## Summary
- add email notification module using SendGrid
- register `@sendgrid/mail` dependency

## Testing
- `npm install --prefix server` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6847668491c88323a38ee3df56dc5d67