### PR TITLE
Add draft report generation service

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ These values are for testing only.
 ### Projects
 - `GET /projects` – list all projects
 - `POST /projects` – add a new project (`{ name, description }`)
+- `POST /api/generate-draft-report` – create a draft report from case data
 
 The existing `/portal` routes for case management continue to work as before.
 Use `POST /portal/signup` and `POST /portal/login` with `username` and `password`

--- a/docs/features.md
+++ b/docs/features.md
@@ -78,3 +78,4 @@ This document outlines the planned functionality for the portal.
 
 - Schemas for `User`, `Case`, `Review`, `Booking` and `ClinicalStatement`
 - RESTful endpoints for the frontend to perform CRUD operations
+- Automated draft report generation using clinical statements

--- a/server/db.js
+++ b/server/db.js
@@ -2,6 +2,7 @@ const User = require('./models/User');
 const Project = require('./models/Project');
 const Case = require('./models/Case');
 const Review = require('./models/Review');
+const ClinicalStatement = require('./models/ClinicalStatement');
 
 async function getUsers() {
   return User.find().lean();
@@ -68,6 +69,15 @@ async function getReviewsForCase(caseId) {
   return Review.find({ caseId }).lean();
 }
 
+async function getClinicalStatements() {
+  return ClinicalStatement.find().lean();
+}
+
+async function addClinicalStatement(statement) {
+  const doc = await ClinicalStatement.create(statement);
+  return doc.toObject();
+}
+
 module.exports = {
   getUsers,
   addUser,
@@ -84,4 +94,6 @@ module.exports = {
   getReviews,
   addReview,
   getReviewsForCase,
+  getClinicalStatements,
+  addClinicalStatement,
 };

--- a/server/draftReportService.js
+++ b/server/draftReportService.js
@@ -1,0 +1,39 @@
+const { getClinicalStatements } = require('./db');
+
+async function generateDraftReport(caseData) {
+  const statements = await getClinicalStatements();
+
+  const report = {
+    modificationsSummary: [],
+    attachments: [],
+    IPR: null,
+    photos: caseData.photos || [],
+    clincheckLink: caseData.clincheckLink || '',
+    notes: caseData.notes || '',
+  };
+
+  if (caseData.hasIPR) {
+    const ipr = statements.find((s) => s.key === 'ipr');
+    if (ipr) {
+      report.IPR = ipr.text;
+    }
+  }
+
+  if (caseData.hasAttachments) {
+    const attach = statements.find((s) => s.key === 'attachment');
+    if (attach) {
+      report.attachments.push(attach.text);
+    }
+  }
+
+  // default summary using any statements flagged as 'summary'
+  statements
+    .filter((s) => s.key === 'summary')
+    .forEach((s) => report.modificationsSummary.push(s.text));
+
+  return report;
+}
+
+module.exports = {
+  generateDraftReport,
+};

--- a/server/index.js
+++ b/server/index.js
@@ -28,6 +28,7 @@ const {
   addReview,
   getReviewsForCase,
 } = require('./db');
+const { generateDraftReport } = require('./draftReportService');
 
 const { sendCaseReady, sendNewRequest } = require('./notificationService');
 
@@ -344,6 +345,16 @@ app.put('/api/cases/:id/status', async (req, res) => {
     console.error('Notification error:', err.message);
   }
   res.json(updated);
+});
+
+app.post('/api/generate-draft-report', async (req, res) => {
+  try {
+    const report = await generateDraftReport(req.body);
+    res.json(report);
+  } catch (err) {
+    console.error('Draft report error:', err.message);
+    res.status(500).json({ error: 'Failed to generate draft report' });
+  }
 });
 
 

--- a/server/models/ClinicalStatement.js
+++ b/server/models/ClinicalStatement.js
@@ -1,0 +1,8 @@
+const mongoose = require('mongoose');
+
+const clinicalStatementSchema = new mongoose.Schema({
+  key: { type: String, required: true },
+  text: { type: String, required: true },
+});
+
+module.exports = mongoose.model('ClinicalStatement', clinicalStatementSchema);


### PR DESCRIPTION
## Summary
- add ClinicalStatement model and DB helpers
- create draftReportService with `generateDraftReport`
- expose `/api/generate-draft-report` endpoint
- document the new endpoint and feature

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684768424bd083239aeda38e3c662f32