### PR TITLE
Add case card view with dropdown actions

### DIFF
--- a/client/src/components/CaseCard.jsx
+++ b/client/src/components/CaseCard.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import {
+  Box,
+  Heading,
+  Link,
+  SimpleGrid,
+  Image,
+  Button,
+  Menu,
+  MenuButton,
+  MenuList,
+  MenuItem,
+} from '@chakra-ui/react';
+import { ChevronDownIcon } from '@chakra-ui/icons';
+
+function CaseCard({ detail, role, onClose, onAssign, children }) {
+  if (!detail) return null;
+
+  const actions = [];
+  if (role === 'specialist' && !detail.assignedTo && onAssign) {
+    actions.push(
+      <MenuItem key="claim" onClick={() => onAssign(detail.id)}>
+        Claim Case
+      </MenuItem>,
+    );
+  }
+  if (onClose) {
+    actions.push(
+      <MenuItem key="close" onClick={() => onClose(detail.id)}>
+        Close Case
+      </MenuItem>,
+    );
+  }
+
+  return (
+    <Box borderWidth="1px" rounded="md" p={2} mb={4}>
+      <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
+        <Heading as="h3" size="md">
+          Case {detail.clinCheckId}
+        </Heading>
+        {actions.length > 0 && (
+          <Menu>
+            <MenuButton as={Button} rightIcon={<ChevronDownIcon />}>
+              Actions
+            </MenuButton>
+            <MenuList>{actions}</MenuList>
+          </Menu>
+        )}
+      </Box>
+      {detail.link && (
+        <Link href={detail.link} color="blue.500" textDecor="underline">
+          ClinCheck Link
+        </Link>
+      )}
+      <SimpleGrid columns={4} spacing={2} mt={2}>
+        {Array.isArray(detail.photos) &&
+          detail.photos.map((p) => (
+            <Image key={p} src={p} alt="photo" objectFit="cover" h="6rem" />
+          ))}
+      </SimpleGrid>
+      {children}
+    </Box>
+  );
+}
+
+export default CaseCard;

--- a/client/src/pages/Portal.jsx
+++ b/client/src/pages/Portal.jsx
@@ -16,6 +16,7 @@ import {
 import CaseList from '../components/CaseList.jsx';
 import FileUploader from '../components/FileUploader.jsx';
 import ReviewForm from '../components/ReviewForm.jsx';
+import CaseCard from '../components/CaseCard.jsx';
 
 const API_BASE = getApiBase();
 
@@ -184,26 +185,12 @@ function Portal() {
       </Select>
 
       {caseDetail && selectedId && (
-        <Box mb={4} borderWidth="1px" p={2}>
-          <Heading as="h3" size="md" mb={2}>
-            Case {caseDetail.clinCheckId}
-          </Heading>
-          {caseDetail.link && (
-            <Link href={caseDetail.link} color="blue.500" textDecor="underline">
-              ClinCheck Link
-            </Link>
-          )}
-          <SimpleGrid columns={4} spacing={2} mt={2}>
-            {Array.isArray(caseDetail.photos) &&
-              caseDetail.photos.map((p) => (
-                <Image key={p} src={p} alt="photo" objectFit="cover" h="6rem" />
-              ))}
-          </SimpleGrid>
-          {role === 'specialist' && !caseDetail.assignedTo && (
-            <Button onClick={() => assignCase(caseDetail.id)} bg="blue.500" color="white" mt={2}>
-              Claim Case
-            </Button>
-          )}
+        <CaseCard
+          detail={caseDetail}
+          role={role}
+          onClose={closeCase}
+          onAssign={assignCase}
+        >
           <Heading as="h4" size="sm" mt={2}>
             Reviews
           </Heading>
@@ -215,7 +202,7 @@ function Portal() {
           {role === 'specialist' && caseDetail.status !== 'completed' && (
             <ReviewForm />
           )}
-        </Box>
+        </CaseCard>
       )}
       <CaseList
         cases={Array.isArray(cases)


### PR DESCRIPTION
## Summary
- show selected case in a new `CaseCard` component
- include dropdown menu for closing or claiming cases

## Testing
- `npm run lint --prefix client` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847708d94b88323832f0954de37ddb4